### PR TITLE
Make API accessible from browser cross-site JS request.

### DIFF
--- a/api.php
+++ b/api.php
@@ -4,6 +4,7 @@ require_once "common.php";
 
 header('Cache-Control: no-cache, must-revalidate');
 header('Content-type: application/json');
+header('Access-Control-Allow-Origin: *');
 
 
 // Get data from db


### PR DESCRIPTION
API is not available to browser cross-site request like:
```javascript
fetch("https://ofp-faguss.com/schedule/api?mod=all")
```

Would it be possible to enable it?